### PR TITLE
Sort files by name before hashing

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ function prep(fs, Promise) {
                     console.error(err);
                     return reject(err);
                 } else {
-                    return resolve(files);
+                    return resolve(files.sort());
                 }
             });
         });

--- a/test/test.js
+++ b/test/test.js
@@ -237,6 +237,25 @@ describe('Generating a hash over a folder, it', function () {
         });
     });
 
+    it('generates the same hash if the folders have the same content but different file order', function () {
+        const hashElement = prep(Volume.fromJSON({
+            'first/file1': 'content',
+            'first/folder/file2': 'abc',
+            'first/folder/file3': 'abcd',
+            '2nd/folder/first/file1': 'content',
+            '2nd/folder/first/folder/file3': 'abcd',
+            '2nd/folder/first/folder/file2': 'abc'
+        }));
+
+        return Promise.all([
+            hashElement('first'),
+            hashElement('first', path.join('2nd', 'folder'))
+        ]).then(([first, second]) => {
+            should.exist(first.hash);
+            first.hash.should.equal(second.hash);
+        });
+    })
+
     it('generates the same hash if the only file with different content is ignored', function () {
         const hashElement = prep(Volume.fromJSON({
             'base/file1': 'content',


### PR DESCRIPTION
This PR adds sorting of the directory listing.

Node's `fs.readdir()` does not guarantee that the resulting array of filenames is sorted in any order. Thus current hashing is platform-dependent. We had an evidence of a different hashes of the same folder on Windows 10 and Linux.