### PR TITLE
Allow setting include and exclude as functions in addition to arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ const options = {
         <tr>
             <td>exclude</td>
             <td>
-                <span>Array.&lt;string&gt;</span>
+                <span>Array.&lt;string&gt; || Function</span>
             </td>
             <td>
                 &lt;optional&gt;<br>
@@ -237,12 +237,12 @@ const options = {
             <td>
                 []
             </td>
-            <td>Array of optional exclude glob patterns, see <a href="https://github.com/isaacs/minimatch#features">minimatch doc</a></td>
+            <td>Array of optional exclude glob patterns, see <a href="https://github.com/isaacs/minimatch#features">minimatch doc</a>. Can also be a function which returns true if the passed file is excluded.</td>
         </tr>
         <tr>
             <td>include</td>
             <td>
-                <span>Array.&lt;string&gt;</span>
+                <span>Array.&lt;string&gt; || Function</span>
             </td>
             <td>
                 &lt;optional&gt;<br>
@@ -250,7 +250,7 @@ const options = {
             <td>
                 []
             </td>
-            <td>Array of optional include glob patterns, see <a href="https://github.com/isaacs/minimatch#features">minimatch doc</a></td>
+            <td>Array of optional include glob patterns, see <a href="https://github.com/isaacs/minimatch#features">minimatch doc</a>. Can also be a function which returns true if the passed file is included.</td>
         </tr>
         <tr>
             <td>matchBasename</td>

--- a/examples/ignore-gitignore.js
+++ b/examples/ignore-gitignore.js
@@ -1,0 +1,27 @@
+/**
+ * Shows how the exlcude option can be used with a function.
+ * 
+ * Real-life usage could be to exclude gitignored files
+ */
+
+const { hashElement } = require('../index')
+const fs = require('fs');
+const ignore = require('ignore'); 
+
+const gitignoreContents = fs.readFileSync('../.gitignore').toString().split('\n');
+const ig = ignore().add(gitignoreContents);
+
+function shouldExclude(name){
+  return ig.ignores(name);
+}
+
+hashElement('../', {
+  files: {
+    exclude: shouldExclude
+  },
+  folders: {
+    exclude: shouldExclude
+  }
+}).then(hash => {
+  console.log('hash of everything that is not gitignored: ', hash)
+});

--- a/index.js
+++ b/index.js
@@ -159,18 +159,18 @@ function prep(fs, Promise) {
 
     function ignore(name, path, rules) {
         if (rules.exclude) {
-            if (rules.matchBasename && rules.exclude.test(name)) {
+            if (rules.matchBasename && rules.exclude(name)) {
                 log.match(`exclude basename '${path}'`);
                 return true;
-            } else if (rules.matchPath && rules.exclude.test(path)) {
+            } else if (rules.matchPath && rules.exclude(path)) {
                 log.match(`exclude path '${path}'`);
                 return true;
             }
         } else if (rules.include) {
-            if (rules.matchBasename && rules.include.test(name)) {
+            if (rules.matchBasename && rules.include(name)) {
                 log.match(`include basename '${path}'`);
                 return false;
-            } else if (rules.matchPath && rules.include.test(path)) {
+            } else if (rules.matchPath && rules.include(path)) {
                 log.match(`include path '${path}'`);
                 return false;
             } else {
@@ -281,13 +281,17 @@ function notUndefined(obj) {
 }
 
 function reduceGlobPatterns(globs) {
-    if (!globs || !Array.isArray(globs) || globs.length === 0) {
+    if (typeof globs === 'function') {
+      return globs;
+    }
+    else if (!globs || !Array.isArray(globs) || globs.length === 0) {
         return undefined;
     } else {
         // combine globs into one single RegEx
-        return new RegExp(globs.reduce((acc, exclude) => {
+        const regex = new RegExp(globs.reduce((acc, exclude) => {
             return acc + '|' + minimatch.makeRe(exclude).source;
         }, '').substr(1));
+        return param => regex.test(param);
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -506,6 +506,12 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "ignore": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
+      "integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "chai": "^4.0.2",
     "chai-as-promised": "^7.1.1",
+    "ignore": "^5.1.2",
     "jsdoc": "3.5.5",
     "memfs": "^2.8.0",
     "mocha": "^6.0.2",

--- a/test/folders.js
+++ b/test/folders.js
@@ -28,6 +28,29 @@ describe('Generating a hash over a folder, it', function () {
         return hashElement('abc').then(checkChildren);
     });
 
+    it('ignores things with an exclude function', function () {
+        const hashElement = prep(Volume.fromJSON({
+            'abc/def': 'abc/def',
+            'abc/ghi/jkl/file.js': 'content',
+            'abc/ghi/jkl/file2.js': 'content',
+            'abc/ghi/folder/data.json': 'content',
+            'abc/ghi/folder/subfolder/today.log': 'content'
+        }));
+
+        const options = {
+          folders: {
+            exclude: path => path.includes('ghi')
+          }
+        };
+
+        const checkChildren = current => {
+            current.children.length.should.equal(1);
+            current.children[0].name.should.equal('def');
+        };
+
+        return hashElement('abc', options).then(checkChildren);
+    });
+
     it('generates different hashes if the folders have the same content but different names', function () {
         const hashElement = prep(Volume.fromJSON({
             'folder1/file1': 'content',


### PR DESCRIPTION
I wanted to exclude all gitignored files but could not just pass the gitignore contents to  the exclude array in its current form. This seems like a good way to add flexibility to include and exclude rules. See the example for exactly what I want to do that's difficult right now. 