### PR TITLE
Add option parameter to createHash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## Unreleased (2025)
+## 4.1.0 (2025-01-02)
+- Pass options to crypto.createHash from #217
 - Update dependencies
 
 ## 4.0.4 (2023-01-11)

--- a/README.md
+++ b/README.md
@@ -509,6 +509,19 @@ hashElement(__dirname, options, (error, hash) => {
     console.log(hash.toString());
   }
 });
+
+// pass algoOptions (example: shake256)
+// see https://nodejs.org/api/crypto.html#cryptocreatehashalgorithm-options
+// only supported in node v12.8 and higher
+const options = { algo: 'shake256', algoOptions:{ outputLength: 5 }, files: { exclude: ['.*'], matchBasename: true } };
+hashElement(__dirname, options, (error, hash) => {
+  if (error) {
+    return console.error('hashing failed:', error);
+  } else {
+    console.log('Result for folder "' + __dirname + '":');
+    console.log(hash.toString());
+  }
+});
 ```
 
 ## Behavior

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 
 const defaultOptions = {
   algo: 'sha1', // see crypto.getHashes() for options
+  algoOptions: {},
   encoding: 'base64', // 'base64', 'base64url', 'hex' or 'binary'
   files: {
     exclude: [],
@@ -167,7 +168,7 @@ function prep(fs) {
 
     return new Promise((resolve, reject) => {
       try {
-        const hash = crypto.createHash(options.algo);
+        const hash = crypto.createHash(options.algo, options.algoOptions);
         if (
           options.files.ignoreBasename ||
           options.ignoreBasenameOnce ||
@@ -213,7 +214,7 @@ function prep(fs) {
   function symLinkIgnoreTargetContent(name, target, options, isRootElement) {
     delete options.skipMatching; // only used for the root level
     log.symlink('ignoring symbolic link target content');
-    const hash = crypto.createHash(options.algo);
+    const hash = crypto.createHash(options.algo, options.algoOptions);
     if (!options.symbolicLinks.ignoreBasename && !(isRootElement && options.files.ignoreRootName)) {
       log.symlink('hash basename');
       hash.update(name);
@@ -237,7 +238,7 @@ function prep(fs) {
       const temp = await hashElementPromise(stats, dir, options, isRootElement);
 
       if (!options.symbolicLinks.ignoreTargetPath) {
-        const hash = crypto.createHash(options.algo);
+        const hash = crypto.createHash(options.algo, options.algoOptions);
         hash.update(temp.hash);
         log.symlink('hash targetpath');
         hash.update(target);
@@ -247,7 +248,7 @@ function prep(fs) {
     } catch (err) {
       if (options.symbolicLinks.ignoreTargetContentAfterError) {
         log.symlink(`Ignoring error "${err.code}" when hashing symbolic link ${name}`, err);
-        const hash = crypto.createHash(options.algo);
+        const hash = crypto.createHash(options.algo, options.algoOptions);
         if (
           !options.symbolicLinks.ignoreBasename &&
           !(isRootElement && options.files.ignoreRootName)
@@ -314,6 +315,7 @@ function parseParameters(args) {
   if (!isObject(options_)) options_ = {};
   const options = {
     algo: options_.algo || defaultOptions.algo,
+    algoOptions: options_.algoOptions || defaultOptions.algoOptions,
     encoding: options_.encoding || defaultOptions.encoding,
     files: Object.assign({}, defaultOptions.files, options_.files),
     folders: Object.assign({}, defaultOptions.folders, options_.folders),
@@ -334,7 +336,7 @@ const HashedFolder = function HashedFolder(name, children, options, isRootElemen
   this.name = name;
   this.children = children;
 
-  const hash = crypto.createHash(options.algo);
+  const hash = crypto.createHash(options.algo, options.algoOptions);
   if (
     options.folders.ignoreBasename ||
     options.ignoreBasenameOnce ||

--- a/test/base.js
+++ b/test/base.js
@@ -35,6 +35,26 @@ describe('Should generate hashes', function () {
       };
       return hashElement(basename, dir, options).then(checkHash);
     });
+
+    it('with algoOptions passed', function () {
+      const checkAlgoOptionHash = result => {
+        should.exist(result);
+        should.exist(result.hash);
+        result.hash.should.equal('d89f885449');
+      };
+
+      var options = {
+        algo: 'shake256',
+        algoOptions: { outputLength: 5 },
+        encoding: 'hex',
+        excludes: [],
+        match: {
+          basename: false,
+          path: false,
+        },
+      };
+      return hashElement(basename, dir, options).then(checkAlgoOptionHash);
+    });
   });
 
   describe('when executed with an error-first callback', function () {


### PR DESCRIPTION
I created this MR to finally merge https://github.com/marc136/node-folder-hash/pull/217

The [crypto.createHash(algorithm[, options])](https://nodejs.org/docs/latest-v12.x/api/crypto.html#crypto_crypto_createhash_algorithm_options) is available since node.js 12.8

