### PR TITLE
Fix error handling

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -64,7 +64,7 @@ function parseArgs(args) {
 }
 
 function error(err) {
-  console.error('ERROR:', ex.message || ex.name || ex);
+  console.error('ERROR:', err.message || err.name || err);
   process.exit(1);
 }
 


### PR DESCRIPTION
if something going wrong i have the following error
```
cli.js:69
  console.error('ERROR:', ex.message || ex.name || ex);
                          ^

ReferenceError: ex is not defined
    at error (folder-hash/cli.js:69:27)
```

so please check this small fix